### PR TITLE
Fix use item events being processed twice (caused crash)

### DIFF
--- a/port/13_InventoryAndPowerUps_02_carrying_items/src/systems/mod.rs
+++ b/port/13_InventoryAndPowerUps_02_carrying_items/src/systems/mod.rs
@@ -102,7 +102,9 @@ pub fn build_system_sets(app: &mut App) {
         MonsterCombat,
         ConditionSet::new()
             .run_if_resource_equals(MonsterTurn)
-            .with_system(use_items::use_items)
+            // We can't do this with the current (event-based) design, otherwise events are processed
+            // twice; see page 254 of the book for the original.
+            // .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
     );

--- a/port/14_DeeperDungeons/src/systems/mod.rs
+++ b/port/14_DeeperDungeons/src/systems/mod.rs
@@ -102,7 +102,9 @@ pub fn build_system_sets(app: &mut App) {
         MonsterCombat,
         ConditionSet::new()
             .run_if_resource_equals(MonsterTurn)
-            .with_system(use_items::use_items)
+            // We can't do this with the current (event-based) design, otherwise events are processed
+            // twice; see page 254 of the book for the original.
+            // .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
     );

--- a/port/15_Loot_01_loot_tables/src/systems/mod.rs
+++ b/port/15_Loot_01_loot_tables/src/systems/mod.rs
@@ -102,7 +102,9 @@ pub fn build_system_sets(app: &mut App) {
         MonsterCombat,
         ConditionSet::new()
             .run_if_resource_equals(MonsterTurn)
-            .with_system(use_items::use_items)
+            // We can't do this with the current (event-based) design, otherwise events are processed
+            // twice; see page 254 of the book for the original.
+            // .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
     );

--- a/port/15_Loot_02_better_combat/src/systems/mod.rs
+++ b/port/15_Loot_02_better_combat/src/systems/mod.rs
@@ -112,7 +112,9 @@ pub fn build_system_sets(app: &mut App) {
         MonsterCombat,
         ConditionSet::new()
             .run_if_resource_equals(MonsterTurn)
-            .with_system(use_items::use_items)
+            // We can't do this with the current (event-based) design, otherwise events are processed
+            // twice; see page 254 of the book for the original.
+            // .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
     );


### PR DESCRIPTION
See comment for the reference.

Closes #2.