### PR TITLE
Correct ActivateItem: Remove Component attribute, and relocate

### DIFF
--- a/port/13_InventoryAndPowerUps_02_carrying_items/src/components.rs
+++ b/port/13_InventoryAndPowerUps_02_carrying_items/src/components.rs
@@ -50,12 +50,6 @@ pub struct Name(pub String);
 pub struct Carried(pub Entity);
 
 #[derive(Component)]
-pub struct ActivateItem {
-    pub used_by: Entity,
-    pub item: Entity,
-}
-
-#[derive(Component)]
 pub struct FieldOfView {
     pub visible_tiles: HashSet<Point>,
     pub radius: i32,

--- a/port/13_InventoryAndPowerUps_02_carrying_items/src/events.rs
+++ b/port/13_InventoryAndPowerUps_02_carrying_items/src/events.rs
@@ -18,3 +18,8 @@ pub struct WantsToAttack {
     pub attacker: Entity,
     pub victim: Entity,
 }
+
+pub struct ActivateItem {
+    pub used_by: Entity,
+    pub item: Entity,
+}

--- a/port/14_DeeperDungeons/src/components.rs
+++ b/port/14_DeeperDungeons/src/components.rs
@@ -52,12 +52,6 @@ pub struct Name(pub String);
 pub struct Carried(pub Entity);
 
 #[derive(Component)]
-pub struct ActivateItem {
-    pub used_by: Entity,
-    pub item: Entity,
-}
-
-#[derive(Component)]
 pub struct FieldOfView {
     pub visible_tiles: HashSet<Point>,
     pub radius: i32,

--- a/port/14_DeeperDungeons/src/events.rs
+++ b/port/14_DeeperDungeons/src/events.rs
@@ -18,3 +18,8 @@ pub struct WantsToAttack {
     pub attacker: Entity,
     pub victim: Entity,
 }
+
+pub struct ActivateItem {
+    pub used_by: Entity,
+    pub item: Entity,
+}

--- a/port/15_Loot_01_loot_tables/src/components.rs
+++ b/port/15_Loot_01_loot_tables/src/components.rs
@@ -52,12 +52,6 @@ pub struct Name(pub String);
 pub struct Carried(pub Entity);
 
 #[derive(Component)]
-pub struct ActivateItem {
-    pub used_by: Entity,
-    pub item: Entity,
-}
-
-#[derive(Component)]
 pub struct FieldOfView {
     pub visible_tiles: HashSet<Point>,
     pub radius: i32,

--- a/port/15_Loot_01_loot_tables/src/events.rs
+++ b/port/15_Loot_01_loot_tables/src/events.rs
@@ -18,3 +18,8 @@ pub struct WantsToAttack {
     pub attacker: Entity,
     pub victim: Entity,
 }
+
+pub struct ActivateItem {
+    pub used_by: Entity,
+    pub item: Entity,
+}

--- a/port/15_Loot_02_better_combat/src/components.rs
+++ b/port/15_Loot_02_better_combat/src/components.rs
@@ -55,12 +55,6 @@ pub struct Name(pub String);
 pub struct Carried(pub Entity);
 
 #[derive(Component)]
-pub struct ActivateItem {
-    pub used_by: Entity,
-    pub item: Entity,
-}
-
-#[derive(Component)]
 pub struct Damage(pub i32);
 
 #[derive(Component)]

--- a/port/15_Loot_02_better_combat/src/events.rs
+++ b/port/15_Loot_02_better_combat/src/events.rs
@@ -18,3 +18,8 @@ pub struct WantsToAttack {
     pub attacker: Entity,
     pub victim: Entity,
 }
+
+pub struct ActivateItem {
+    pub used_by: Entity,
+    pub item: Entity,
+}


### PR DESCRIPTION
It's an event, not a component!

Closes #3.